### PR TITLE
Build on Ubuntu 18.04

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -172,7 +172,7 @@ obj/%.o : src/%.c Makefile | obj/.d
 
 obj/%.o : src/%.C Makefile | obj/.d
 	@$(ECHO_E) "\t[CXX] $@"
-	$(SHOWCL)$(CC) $(CFLAGS) -o $@ -c $<
+	$(SHOWCL)$(CC) $(CXXFLAGS) $(CFLAGS) -o $@ -c $<
 
 deps/%.d : src/%.c Makefile | deps/.d
 	@$(ECHO_E) "\t[DEP] $@"
@@ -184,14 +184,9 @@ deps/%.d : src/%.C Makefile | deps/.d
 	$(SHOWCL)$(CC) $(CFLAGS) -o $@ -MG -MM $<
 	$(SHOWCL)sed -e 's,$(notdir $*.o):,$@ obj/$*.o:,' -i $@
 
-# Fop changed behaviour between 1.0 and 1.1 as to how a <base> tag in the
-# configuration file is interpreted: in 1.0 it is taken relative to the current
-# directory, while in fop 1.1 is is relative to one of the files (I haven't
-# checked which one). Changing directory is thus necessary to ensure that the
-# rule works with both fop versions.
-doc/pdf/%.pdf: doc/tmp/%.fo | doc/pdf/.d
+doc/pdf/%.pdf: doc/tmp/%.fo doc/docbook/fop.xconf | doc/pdf/.d
 	@$(ECHO_E) "\t[PDF] $@"
-	$(SHOWCL)cd doc/docbook && $(FOP) -q -c fop.xconf -fo $(abspath $<) -pdf $(abspath $@)
+	$(SHOWCL)$(FOP) -q -c doc/docbook/fop.xconf -fo $< -pdf $@
 
 doc/tmp/%.fo: doc/tmp/%.xml
 	@$(ECHO_E) "\t[FO] $@"

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -17,6 +17,8 @@ AR := ar
 RANLIB ?= ranlib
 ECHO_E ?= /bin/echo -e   # Don't just use echo: in dash it doesn't process -e
 
+CXXFLAGS = -std=c++98    # Uses auto_ptr heavily, and it's deprecated in C++11
+
 CFLAGS ?= -W -Wall
 LDFLAGS ?=
 

--- a/doc/docbook/fop.xconf
+++ b/doc/docbook/fop.xconf
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <fop version="1.0">
+    <base>.</base>
     <source-resolution>72</source-resolution>
     <target-resolution>72</target-resolution>
 

--- a/src/abacusd.C
+++ b/src/abacusd.C
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <memory>
 #include <cassert>
+#include <cstring>
 
 #include "acmconfig.h"
 #include "logger.h"

--- a/src/act_bonus.C
+++ b/src/act_bonus.C
@@ -18,6 +18,7 @@
 
 #include <sstream>
 #include <memory>
+#include <cstring>
 
 using namespace std;
 

--- a/src/act_clarify.C
+++ b/src/act_clarify.C
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <memory>
+#include <cstring>
 #include <time.h>
 
 using namespace std;

--- a/src/act_mark.C
+++ b/src/act_mark.C
@@ -28,6 +28,7 @@
 #include <time.h>
 #include <sstream>
 #include <memory>
+#include <cstring>
 
 using namespace std;
 

--- a/src/act_passwd.C
+++ b/src/act_passwd.C
@@ -20,6 +20,7 @@
 #include <string>
 #include <sstream>
 #include <memory>
+#include <cstring>
 
 using namespace std;
 

--- a/src/act_problemmanip.C
+++ b/src/act_problemmanip.C
@@ -25,6 +25,7 @@
 #include <iterator>
 #include <sstream>
 #include <memory>
+#include <cstring>
 #include <sys/types.h>
 #include <regex.h>
 #include <time.h>

--- a/src/act_submit.C
+++ b/src/act_submit.C
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <vector>
 #include <string>
+#include <cstring>
 #include <memory>
 #include <time.h>
 

--- a/src/message.C
+++ b/src/message.C
@@ -93,7 +93,8 @@ bool Message::makeMessage() {
 	} catch(...) {
 		log(LOG_ERR, "Failed to pack message, exception caught");
 		if (db)
-			db->release(); db = NULL;
+			db->release();
+		db = NULL;
 		return false;
 		// I only ever expect a memory exception...
 	}
@@ -195,7 +196,7 @@ Message* Message::buildMessage(uint32_t server_id, uint32_t message_id,
 
 	Message *tmp = func();
 
-	if(~0U == tmp->buildMessage(server_id, message_id, time, signature, data,
+	if(!tmp->buildMessage(server_id, message_id, time, signature, data,
 				data_len, NULL, 0)) {
 		delete tmp;
 		return NULL;

--- a/src/message_createuser.C
+++ b/src/message_createuser.C
@@ -7,6 +7,7 @@
  *
  * $Id$
  */
+#include <cstring>
 #include "message_createuser.h"
 #include "message_type_ids.h"
 #include "logger.h"

--- a/src/messageblock.C
+++ b/src/messageblock.C
@@ -13,6 +13,7 @@
 
 #include <sstream>
 #include <string>
+#include <cstring>
 #include <cassert>
 
 using namespace std;

--- a/src/problemmarker.C
+++ b/src/problemmarker.C
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstring>
 
 using namespace std;
 

--- a/src/sigsegv.c
+++ b/src/sigsegv.c
@@ -48,7 +48,7 @@ using __cxxabiv1::__cxa_demangle;
 
 #if defined(REG_RIP)
 # define SIGSEGV_STACK_IA64
-# define REGFORMAT "%016lx"
+# define REGFORMAT "%016llx"
 #elif defined(REG_EIP)
 # define SIGSEGV_STACK_X86
 # define REGFORMAT "%08x"

--- a/src/threadssl.C
+++ b/src/threadssl.C
@@ -25,20 +25,6 @@ using namespace std;
 static int n_ssl_locks;
 static pthread_mutex_t *ssl_locks;
 
-static void ssl_locking_function(int mode, int n, const char *file, int line) {
-	(void) file;
-	(void) line;
-
-	if (mode & CRYPTO_LOCK)
-		pthread_mutex_lock(&ssl_locks[n]);
-	else
-		pthread_mutex_unlock(&ssl_locks[n]);
-}
-
-static unsigned long ssl_id_callback(void) {
-	return (unsigned long) pthread_self();
-}
-
 void ThreadSSL::initialise() {
 	n_ssl_locks = CRYPTO_num_locks();
 	ssl_locks = (pthread_mutex_t *) malloc(n_ssl_locks * sizeof(pthread_mutex_t));

--- a/src/udtcpmessenger.C
+++ b/src/udtcpmessenger.C
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include <cstring>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <sys/mman.h>


### PR DESCRIPTION
I upgraded my machine to Ubuntu 18.04, and as a result there were a bunch of compiler errors and warnings. This fixes up some of it.

There are still warnings about TLSv1_server_method being deprecated. It looks like the recommended replacement is only available from OpenSSL 1.1, so fixing that would require either `#ifdef` stuff or dropping support for 1.0. We should at least change it to TLSv1_2_server_method though given that there are known weaknesses in older versions of TLS.